### PR TITLE
Add SubdomainStore for self-hosted relay + update command

### DIFF
--- a/cmd/wormhole/main.go
+++ b/cmd/wormhole/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -37,6 +39,7 @@ func main() {
 	rootCmd.AddCommand(statusCmd())
 	rootCmd.AddCommand(versionCmd())
 	rootCmd.AddCommand(uninstallCmd())
+	rootCmd.AddCommand(updateCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -449,4 +452,207 @@ func uninstallCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&purge, "purge", false, "Also remove config directory (~/.wormhole/)")
 
 	return cmd
+}
+
+// ── update command ────────────────────────────────────────────────────────────
+
+func updateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update",
+		Short: "Update wormhole to the latest version",
+		Long: `Check for the latest version and update the wormhole binary in place.
+Detects the install method (Homebrew, curl, go install) and uses the appropriate update path.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runUpdate()
+		},
+	}
+}
+
+func runUpdate() error {
+	fmt.Printf("wormhole %s — checking for updates...\n\n", version)
+
+	latest, downloadURL, err := fetchLatestRelease()
+	if err != nil {
+		return fmt.Errorf("checking latest release: %w", err)
+	}
+
+	if latest == version {
+		fmt.Printf("  Already up to date (v%s).\n", version)
+		return nil
+	}
+
+	fmt.Printf("  New version available: %s → %s\n\n", version, latest)
+
+	// 1. Homebrew?
+	if brewOut, berr := exec.Command("brew", "list", "--formula").Output(); berr == nil {
+		if strings.Contains(string(brewOut), "wormhole") {
+			fmt.Println("  Updating via Homebrew...")
+			cmd := exec.Command("brew", "upgrade", "MuhammadHananAsghar/tap/wormhole")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("brew upgrade failed: %w", err)
+			}
+			fmt.Printf("\n  Updated to %s via Homebrew.\n", latest)
+			return nil
+		}
+	}
+
+	// 2. go install?
+	if gopath := os.Getenv("GOPATH"); gopath != "" {
+		gobin := filepath.Join(gopath, "bin", "wormhole")
+		if self, _ := os.Executable(); self == gobin {
+			fmt.Println("  Updating via go install...")
+			cmd := exec.Command("go", "install", "github.com/MuhammadHananAsghar/wormhole/cmd/wormhole@latest")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("go install failed: %w", err)
+			}
+			fmt.Printf("\n  Updated to %s via go install.\n", latest)
+			return nil
+		}
+	}
+	if home, _ := os.UserHomeDir(); home != "" {
+		gobin := filepath.Join(home, "go", "bin", "wormhole")
+		if self, _ := os.Executable(); self == gobin {
+			fmt.Println("  Updating via go install...")
+			cmd := exec.Command("go", "install", "github.com/MuhammadHananAsghar/wormhole/cmd/wormhole@latest")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("go install failed: %w", err)
+			}
+			fmt.Printf("\n  Updated to %s via go install.\n", latest)
+			return nil
+		}
+	}
+
+	// 3. Direct binary replacement.
+	if downloadURL == "" {
+		return fmt.Errorf("no compatible binary found for %s/%s in the latest release", runtime.GOOS, runtime.GOARCH)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot determine current binary path: %w", err)
+	}
+
+	fmt.Printf("  Downloading %s...\n", downloadURL)
+
+	tmpDir, err := os.MkdirTemp("", "wormhole-update-*")
+	if err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, "wormhole.tar.gz")
+	if err := downloadFile(downloadURL, archivePath); err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+
+	extractCmd := exec.Command("tar", "-xzf", archivePath, "-C", tmpDir)
+	if out, err := extractCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("extraction failed: %s", strings.TrimSpace(string(out)))
+	}
+
+	newBinary := filepath.Join(tmpDir, "wormhole")
+	if _, err := os.Stat(newBinary); err != nil {
+		return fmt.Errorf("extracted binary not found")
+	}
+
+	fmt.Printf("  Replacing %s...\n", self)
+	if err := replaceBinary(self, newBinary); err != nil {
+		return fmt.Errorf("replacing binary: %w", err)
+	}
+
+	fmt.Printf("\n  Updated to %s.\n", latest)
+	return nil
+}
+
+func fetchLatestRelease() (string, string, error) {
+	apiURL := "https://api.github.com/repos/MuhammadHananAsghar/wormhole/releases/latest"
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var release struct {
+		TagName string `json:"tag_name"`
+		Assets  []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		} `json:"assets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", "", err
+	}
+
+	ver := strings.TrimPrefix(release.TagName, "v")
+
+	archiveName := fmt.Sprintf("wormhole_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	var downloadURL string
+	for _, a := range release.Assets {
+		if a.Name == archiveName {
+			downloadURL = a.BrowserDownloadURL
+			break
+		}
+	}
+
+	return ver, downloadURL, nil
+}
+
+func downloadFile(url, dest string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func replaceBinary(oldPath, newPath string) error {
+	if err := os.Chmod(newPath, 0o755); err != nil {
+		return err
+	}
+
+	if err := os.Rename(newPath, oldPath); err == nil {
+		return nil
+	}
+
+	src, err := os.Open(newPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(oldPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		// Need sudo.
+		cmd := exec.Command("sudo", "cp", newPath, oldPath)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, src)
+	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-sqlite3 v1.14.34 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2J
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-sqlite3 v1.14.34 h1:3NtcvcUnFBPsuRcno8pUtupspG/GM+9nZ88zgJcp6Zk=
+github.com/mattn/go-sqlite3 v1.14.34/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=

--- a/internal/server/subdomain.go
+++ b/internal/server/subdomain.go
@@ -1,0 +1,302 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Errors returned by SubdomainStore operations.
+var (
+	ErrSubdomainTaken = errors.New("subdomain is reserved by another user")
+	ErrNotOwner       = errors.New("subdomain is not owned by this user")
+)
+
+// SubdomainStore manages subdomain reservations and active tunnel tracking.
+// CF mode uses D1 (edge/src/tunnel.ts), self-hosted mode uses this interface
+// backed by SQLite.
+type SubdomainStore interface {
+	// Reserve claims a subdomain for a user. Returns ErrSubdomainTaken if
+	// already reserved by another user. Re-reserving by the same user is a no-op.
+	Reserve(ctx context.Context, subdomain, userID string) error
+
+	// Release removes a subdomain reservation. Returns ErrNotOwner if the
+	// subdomain belongs to a different user. Releasing a nonexistent subdomain
+	// is a no-op.
+	Release(ctx context.Context, subdomain, userID string) error
+
+	// Owner returns the user ID that reserved the subdomain, or empty string
+	// if unreserved.
+	Owner(ctx context.Context, subdomain string) (string, error)
+
+	// IsAvailable returns true if the subdomain is neither reserved nor
+	// actively used by a tunnel.
+	IsAvailable(ctx context.Context, subdomain string) (bool, error)
+
+	// CanClaim returns true if the given user can use this subdomain — either
+	// it's free, or it's reserved by the same user, and no other tunnel is
+	// active on it.
+	CanClaim(ctx context.Context, subdomain, userID string) (bool, error)
+
+	// SetActive marks a subdomain as having an active tunnel connection.
+	SetActive(ctx context.Context, subdomain, clientID string) error
+
+	// ClearActive removes the active tunnel marker for a subdomain.
+	ClearActive(ctx context.Context, subdomain string) error
+
+	// ListByUser returns all subdomains reserved by a user.
+	ListByUser(ctx context.Context, userID string) ([]string, error)
+
+	// IsSystemReserved returns true if the subdomain is a system-reserved name.
+	IsSystemReserved(subdomain string) bool
+
+	// Close releases database resources.
+	Close() error
+}
+
+var systemReserved = map[string]bool{
+	"www": true, "api": true, "relay": true, "admin": true,
+	"mail": true, "app": true, "dashboard": true,
+}
+
+var subdomainRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$`)
+
+// ValidateSubdomain checks that a subdomain is 3-32 lowercase alphanumeric
+// characters or hyphens, not starting or ending with a hyphen.
+func ValidateSubdomain(s string) error {
+	if len(s) < 3 || len(s) > 32 {
+		return fmt.Errorf("subdomain must be 3-32 characters, got %d", len(s))
+	}
+	if !subdomainRegexp.MatchString(s) {
+		return fmt.Errorf("subdomain must be lowercase alphanumeric or hyphens, no leading/trailing hyphens")
+	}
+	return nil
+}
+
+// SQLiteSubdomainStore implements SubdomainStore backed by a local SQLite database.
+// Uses the same schema as the D1 migrations in edge/migrations/.
+type SQLiteSubdomainStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteSubdomainStore opens (or creates) a SQLite database at dbPath and
+// runs the schema migrations. The schema matches edge/migrations/0001 and 0002.
+func NewSQLiteSubdomainStore(dbPath string) (*SQLiteSubdomainStore, error) {
+	db, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON")
+	if err != nil {
+		return nil, fmt.Errorf("opening subdomain database: %w", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("connecting to subdomain database: %w", err)
+	}
+
+	if err := migrate(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrating subdomain database: %w", err)
+	}
+
+	return &SQLiteSubdomainStore{db: db}, nil
+}
+
+func migrate(db *sql.DB) error {
+	// Same schema as edge/migrations/0001_create_tunnels.sql and
+	// edge/migrations/0002_create_reserved_subdomains.sql
+	migrations := []string{
+		`CREATE TABLE IF NOT EXISTS tunnels (
+			subdomain TEXT PRIMARY KEY,
+			client_id TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_tunnels_client_id ON tunnels(client_id)`,
+		`CREATE TABLE IF NOT EXISTS reserved_subdomains (
+			subdomain TEXT PRIMARY KEY,
+			user_id TEXT,
+			reserved_at TEXT NOT NULL DEFAULT (datetime('now'))
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_reserved_user_id ON reserved_subdomains(user_id)`,
+	}
+
+	for _, m := range migrations {
+		if _, err := db.Exec(m); err != nil {
+			return fmt.Errorf("running migration: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteSubdomainStore) Reserve(ctx context.Context, subdomain, userID string) error {
+	// Check if already reserved
+	var existingUser string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT user_id FROM reserved_subdomains WHERE subdomain = ?", subdomain,
+	).Scan(&existingUser)
+
+	if err == nil {
+		// Row exists — same user is fine, different user is an error
+		if existingUser == userID {
+			return nil
+		}
+		return ErrSubdomainTaken
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("checking reservation: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		"INSERT INTO reserved_subdomains (subdomain, user_id) VALUES (?, ?)",
+		subdomain, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("reserving subdomain: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteSubdomainStore) Release(ctx context.Context, subdomain, userID string) error {
+	var existingUser string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT user_id FROM reserved_subdomains WHERE subdomain = ?", subdomain,
+	).Scan(&existingUser)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil // nothing to release
+	}
+	if err != nil {
+		return fmt.Errorf("checking reservation: %w", err)
+	}
+
+	if existingUser != userID {
+		return ErrNotOwner
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		"DELETE FROM reserved_subdomains WHERE subdomain = ? AND user_id = ?",
+		subdomain, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("releasing subdomain: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteSubdomainStore) Owner(ctx context.Context, subdomain string) (string, error) {
+	var userID string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT user_id FROM reserved_subdomains WHERE subdomain = ?", subdomain,
+	).Scan(&userID)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("querying owner: %w", err)
+	}
+	return userID, nil
+}
+
+func (s *SQLiteSubdomainStore) IsAvailable(ctx context.Context, subdomain string) (bool, error) {
+	// Check reservations
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM reserved_subdomains WHERE subdomain = ?", subdomain,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("checking reservation: %w", err)
+	}
+	if count > 0 {
+		return false, nil
+	}
+
+	// Check active tunnels
+	err = s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM tunnels WHERE subdomain = ?", subdomain,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("checking active tunnels: %w", err)
+	}
+	return count == 0, nil
+}
+
+func (s *SQLiteSubdomainStore) CanClaim(ctx context.Context, subdomain, userID string) (bool, error) {
+	// Check active tunnels first
+	var activeCount int
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM tunnels WHERE subdomain = ?", subdomain,
+	).Scan(&activeCount)
+	if err != nil {
+		return false, fmt.Errorf("checking active tunnels: %w", err)
+	}
+	if activeCount > 0 {
+		return false, nil
+	}
+
+	// Check reservations
+	var existingUser string
+	err = s.db.QueryRowContext(ctx,
+		"SELECT user_id FROM reserved_subdomains WHERE subdomain = ?", subdomain,
+	).Scan(&existingUser)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return true, nil // not reserved, not active
+	}
+	if err != nil {
+		return false, fmt.Errorf("checking reservation: %w", err)
+	}
+
+	return existingUser == userID, nil
+}
+
+func (s *SQLiteSubdomainStore) SetActive(ctx context.Context, subdomain, clientID string) error {
+	_, err := s.db.ExecContext(ctx,
+		"INSERT OR REPLACE INTO tunnels (subdomain, client_id) VALUES (?, ?)",
+		subdomain, clientID,
+	)
+	if err != nil {
+		return fmt.Errorf("setting active tunnel: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteSubdomainStore) ClearActive(ctx context.Context, subdomain string) error {
+	_, err := s.db.ExecContext(ctx,
+		"DELETE FROM tunnels WHERE subdomain = ?", subdomain,
+	)
+	if err != nil {
+		return fmt.Errorf("clearing active tunnel: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteSubdomainStore) ListByUser(ctx context.Context, userID string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT subdomain FROM reserved_subdomains WHERE user_id = ? ORDER BY subdomain", userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing subdomains: %w", err)
+	}
+	defer rows.Close()
+
+	var subs []string
+	for rows.Next() {
+		var sub string
+		if err := rows.Scan(&sub); err != nil {
+			return nil, fmt.Errorf("scanning subdomain: %w", err)
+		}
+		subs = append(subs, sub)
+	}
+	return subs, rows.Err()
+}
+
+func (s *SQLiteSubdomainStore) IsSystemReserved(subdomain string) bool {
+	return systemReserved[subdomain]
+}
+
+func (s *SQLiteSubdomainStore) Close() error {
+	return s.db.Close()
+}

--- a/internal/server/subdomain_integration_test.go
+++ b/internal/server/subdomain_integration_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistrationFlow_MatchesCFBehavior simulates the exact registration
+// flow from edge/src/tunnel.ts handleRegistration() but using SQLite.
+func TestRegistrationFlow_MatchesCFBehavior(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "relay.db")
+	store, err := NewSQLiteSubdomainStore(dbPath)
+	require.NoError(t, err)
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// === Scenario 1: Anonymous user gets random subdomain ===
+	randomSub := "k7x9m2"
+	available, err := store.IsAvailable(ctx, randomSub)
+	require.NoError(t, err)
+	assert.True(t, available)
+
+	err = store.SetActive(ctx, randomSub, "client_abc")
+	require.NoError(t, err)
+
+	// Subdomain is now in use
+	available, err = store.IsAvailable(ctx, randomSub)
+	require.NoError(t, err)
+	assert.False(t, available)
+
+	// === Scenario 2: Authenticated user reserves custom subdomain ===
+	err = ValidateSubdomain("myapp")
+	require.NoError(t, err)
+
+	assert.False(t, store.IsSystemReserved("myapp"))
+
+	canClaim, err := store.CanClaim(ctx, "myapp", "user_github_123")
+	require.NoError(t, err)
+	assert.True(t, canClaim)
+
+	err = store.Reserve(ctx, "myapp", "user_github_123")
+	require.NoError(t, err)
+
+	err = store.SetActive(ctx, "myapp", "client_xyz")
+	require.NoError(t, err)
+
+	// === Scenario 3: Different user tries to claim "myapp" ===
+	canClaim, err = store.CanClaim(ctx, "myapp", "user_github_456")
+	require.NoError(t, err)
+	assert.False(t, canClaim, "different user should not be able to claim reserved subdomain")
+
+	// === Scenario 4: System reserved subdomain rejected ===
+	assert.True(t, store.IsSystemReserved("api"))
+	assert.True(t, store.IsSystemReserved("www"))
+
+	// === Scenario 5: Client disconnects — clear active tunnel ===
+	err = store.ClearActive(ctx, randomSub)
+	require.NoError(t, err)
+
+	available, err = store.IsAvailable(ctx, randomSub)
+	require.NoError(t, err)
+	assert.True(t, available, "subdomain should be available after client disconnect")
+
+	// "myapp" still reserved even after clearing active
+	err = store.ClearActive(ctx, "myapp")
+	require.NoError(t, err)
+
+	owner, err := store.Owner(ctx, "myapp")
+	require.NoError(t, err)
+	assert.Equal(t, "user_github_123", owner, "reservation persists after tunnel disconnect")
+
+	// Same user can reclaim
+	canClaim, err = store.CanClaim(ctx, "myapp", "user_github_123")
+	require.NoError(t, err)
+	assert.True(t, canClaim)
+
+	// === Scenario 6: DB persistence — reopen and verify ===
+	store.Close()
+
+	store2, err := NewSQLiteSubdomainStore(dbPath)
+	require.NoError(t, err)
+	defer store2.Close()
+
+	owner, err = store2.Owner(ctx, "myapp")
+	require.NoError(t, err)
+	assert.Equal(t, "user_github_123", owner, "reservation survives DB reopen")
+
+	subs, err := store2.ListByUser(ctx, "user_github_123")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"myapp"}, subs)
+}

--- a/internal/server/subdomain_test.go
+++ b/internal/server/subdomain_test.go
@@ -1,0 +1,259 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T) *SQLiteSubdomainStore {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	store, err := NewSQLiteSubdomainStore(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestNewSQLiteSubdomainStore_CreatesDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	store, err := NewSQLiteSubdomainStore(dbPath)
+	require.NoError(t, err)
+	defer store.Close()
+
+	_, err = os.Stat(dbPath)
+	assert.NoError(t, err, "database file should exist")
+}
+
+func TestNewSQLiteSubdomainStore_InvalidPath(t *testing.T) {
+	_, err := NewSQLiteSubdomainStore("/nonexistent/dir/test.db")
+	assert.Error(t, err)
+}
+
+func TestReserve_Success(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	err := store.Reserve(ctx, "myapp", "user1")
+	assert.NoError(t, err)
+
+	owner, err := store.Owner(ctx, "myapp")
+	require.NoError(t, err)
+	assert.Equal(t, "user1", owner)
+}
+
+func TestReserve_DuplicateSameUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "myapp", "user1"))
+	err := store.Reserve(ctx, "myapp", "user1")
+	assert.NoError(t, err, "same user re-reserving should succeed")
+}
+
+func TestReserve_DuplicateDifferentUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "myapp", "user1"))
+	err := store.Reserve(ctx, "myapp", "user2")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrSubdomainTaken)
+}
+
+func TestRelease_Success(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "myapp", "user1"))
+	err := store.Release(ctx, "myapp", "user1")
+	assert.NoError(t, err)
+
+	owner, err := store.Owner(ctx, "myapp")
+	require.NoError(t, err)
+	assert.Empty(t, owner, "owner should be empty after release")
+}
+
+func TestRelease_WrongUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "myapp", "user1"))
+	err := store.Release(ctx, "myapp", "user2")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotOwner)
+}
+
+func TestRelease_Nonexistent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	err := store.Release(ctx, "nonexistent", "user1")
+	assert.NoError(t, err, "releasing nonexistent subdomain should be a no-op")
+}
+
+func TestOwner_Nonexistent(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	owner, err := store.Owner(ctx, "nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, owner)
+}
+
+func TestIsAvailable_Unreserved(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	available, err := store.IsAvailable(ctx, "fresh")
+	require.NoError(t, err)
+	assert.True(t, available)
+}
+
+func TestIsAvailable_Reserved(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "taken", "user1"))
+
+	available, err := store.IsAvailable(ctx, "taken")
+	require.NoError(t, err)
+	assert.False(t, available)
+}
+
+func TestIsAvailable_ActiveTunnel(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.SetActive(ctx, "live", "client1"))
+
+	available, err := store.IsAvailable(ctx, "live")
+	require.NoError(t, err)
+	assert.False(t, available)
+}
+
+func TestSetActive_And_ClearActive(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	err := store.SetActive(ctx, "myapp", "client1")
+	assert.NoError(t, err)
+
+	available, err := store.IsAvailable(ctx, "myapp")
+	require.NoError(t, err)
+	assert.False(t, available)
+
+	err = store.ClearActive(ctx, "myapp")
+	assert.NoError(t, err)
+
+	available, err = store.IsAvailable(ctx, "myapp")
+	require.NoError(t, err)
+	assert.True(t, available)
+}
+
+func TestCanClaim_NoReservationNoActive(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	ok, err := store.CanClaim(ctx, "free", "user1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCanClaim_ReservedBySameUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "mine", "user1"))
+
+	ok, err := store.CanClaim(ctx, "mine", "user1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestCanClaim_ReservedByOtherUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "theirs", "user1"))
+
+	ok, err := store.CanClaim(ctx, "theirs", "user2")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestCanClaim_ActiveTunnel(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.SetActive(ctx, "busy", "client1"))
+
+	ok, err := store.CanClaim(ctx, "busy", "user2")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestListByUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "app1", "user1"))
+	require.NoError(t, store.Reserve(ctx, "app2", "user1"))
+	require.NoError(t, store.Reserve(ctx, "other", "user2"))
+
+	subs, err := store.ListByUser(ctx, "user1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"app1", "app2"}, subs)
+}
+
+func TestListByUser_Empty(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	subs, err := store.ListByUser(ctx, "nobody")
+	require.NoError(t, err)
+	assert.Empty(t, subs)
+}
+
+func TestSystemReserved(t *testing.T) {
+	store := newTestStore(t)
+
+	tests := []string{"www", "api", "relay", "admin", "mail", "app", "dashboard"}
+	for _, sub := range tests {
+		assert.True(t, store.IsSystemReserved(sub), "should be system reserved: %s", sub)
+	}
+	assert.False(t, store.IsSystemReserved("myapp"))
+}
+
+func TestValidateSubdomain(t *testing.T) {
+	tests := []struct {
+		subdomain string
+		valid     bool
+	}{
+		{"myapp", true},
+		{"my-app", true},
+		{"abc", true},
+		{"a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6", true}, // 32 chars
+		{"ab", false},                                           // too short
+		{"a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q", false},          // 33 chars, too long
+		{"-myapp", false},
+		{"myapp-", false},
+		{"my--app", true},
+		{"MY_APP", false},
+		{"my app", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		err := ValidateSubdomain(tt.subdomain)
+		if tt.valid {
+			assert.NoError(t, err, "subdomain %q should be valid", tt.subdomain)
+		} else {
+			assert.Error(t, err, "subdomain %q should be invalid", tt.subdomain)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **SubdomainStore interface** (`internal/server/subdomain.go`) — dual-track subdomain management for self-hosted relay (SQLite) matching CF edge (D1). Same schema, same behavior.
- **`wormhole update` command** — self-update with auto-detection of install method (Homebrew, go install, direct binary). Fetches from `MuhammadHananAsghar/wormhole` releases.
- **22 tests** including full integration test simulating the CF registration flow against SQLite.

## Test plan
- [x] `go test -race ./...` — all passing
- [x] `go build ./cmd/wormhole/` — compiles clean
- [x] `wormhole update` — correctly hits GitHub API (404 expected, no releases yet)
- [x] `wormhole --help` — shows update command
- [x] Integration test validates: reserve, conflict detection, active tunnels, persistence across DB reopen