### PR TITLE
Add auto-reserve and 3-subdomain rate limit

### DIFF
--- a/edge/src/tunnel.ts
+++ b/edge/src/tunnel.ts
@@ -21,6 +21,7 @@ interface HttpResponseMessage {
 }
 
 const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_SUBDOMAINS_PER_USER = 3;
 
 export class Tunnel implements DurableObject {
   private clientWs: WebSocket | null = null;
@@ -369,6 +370,27 @@ export class Tunnel implements DurableObject {
           error: `Subdomain "${requested}" is already in use.`,
         }));
         return;
+      }
+
+      // Auto-reserve on first use (if not already reserved by this user)
+      if (!reservedRow) {
+        // Enforce per-user limit (max 3 custom subdomains)
+        const countRow = await this.env.DB.prepare(
+          "SELECT COUNT(*) as cnt FROM reserved_subdomains WHERE user_id = ?"
+        ).bind(auth.githubId).first<{ cnt: number }>();
+        const currentCount = countRow?.cnt ?? 0;
+        if (currentCount >= MAX_SUBDOMAINS_PER_USER) {
+          ws.send(JSON.stringify({
+            type: "register_error",
+            error: `Subdomain limit reached (max ${MAX_SUBDOMAINS_PER_USER} per user). Release an existing subdomain first.`,
+          }));
+          return;
+        }
+
+        // Auto-reserve this subdomain for the user
+        await this.env.DB.prepare(
+          "INSERT INTO reserved_subdomains (subdomain, user_id) VALUES (?, ?)"
+        ).bind(requested, auth.githubId).run();
       }
 
       this.subdomain = requested;

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/mattn/go-sqlite3 v1.14.34
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
@@ -25,7 +26,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/mattn/go-sqlite3 v1.14.34 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect

--- a/internal/server/subdomain.go
+++ b/internal/server/subdomain.go
@@ -10,10 +10,15 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+// MaxSubdomainsPerUser is the maximum number of custom subdomains a single user
+// can reserve. Applies to both CF (D1) and self-hosted (SQLite) modes.
+const MaxSubdomainsPerUser = 3
+
 // Errors returned by SubdomainStore operations.
 var (
-	ErrSubdomainTaken = errors.New("subdomain is reserved by another user")
-	ErrNotOwner       = errors.New("subdomain is not owned by this user")
+	ErrSubdomainTaken  = errors.New("subdomain is reserved by another user")
+	ErrNotOwner        = errors.New("subdomain is not owned by this user")
+	ErrLimitReached    = fmt.Errorf("subdomain limit reached (max %d per user)", MaxSubdomainsPerUser)
 )
 
 // SubdomainStore manages subdomain reservations and active tunnel tracking.
@@ -50,6 +55,9 @@ type SubdomainStore interface {
 
 	// ListByUser returns all subdomains reserved by a user.
 	ListByUser(ctx context.Context, userID string) ([]string, error)
+
+	// CountByUser returns the number of subdomains reserved by a user.
+	CountByUser(ctx context.Context, userID string) (int, error)
 
 	// IsSystemReserved returns true if the subdomain is a system-reserved name.
 	IsSystemReserved(subdomain string) bool
@@ -146,6 +154,15 @@ func (s *SQLiteSubdomainStore) Reserve(ctx context.Context, subdomain, userID st
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("checking reservation: %w", err)
+	}
+
+	// Enforce per-user limit before inserting
+	count, err := s.CountByUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("counting user subdomains: %w", err)
+	}
+	if count >= MaxSubdomainsPerUser {
+		return ErrLimitReached
 	}
 
 	_, err = s.db.ExecContext(ctx,
@@ -291,6 +308,17 @@ func (s *SQLiteSubdomainStore) ListByUser(ctx context.Context, userID string) ([
 		subs = append(subs, sub)
 	}
 	return subs, rows.Err()
+}
+
+func (s *SQLiteSubdomainStore) CountByUser(ctx context.Context, userID string) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM reserved_subdomains WHERE user_id = ?", userID,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("counting user subdomains: %w", err)
+	}
+	return count, nil
 }
 
 func (s *SQLiteSubdomainStore) IsSystemReserved(subdomain string) bool {

--- a/internal/server/subdomain_integration_test.go
+++ b/internal/server/subdomain_integration_test.go
@@ -93,4 +93,31 @@ func TestRegistrationFlow_MatchesCFBehavior(t *testing.T) {
 	subs, err := store2.ListByUser(ctx, "user_github_123")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"myapp"}, subs)
+
+	// === Scenario 7: Auto-reserve + rate limit (matches edge behavior) ===
+	// User reserves 2 more subdomains (already has "myapp" = 1)
+	err = store2.Reserve(ctx, "second", "user_github_123")
+	require.NoError(t, err)
+	err = store2.Reserve(ctx, "third", "user_github_123")
+	require.NoError(t, err)
+
+	// 4th subdomain should fail — limit is 3
+	err = store2.Reserve(ctx, "fourth", "user_github_123")
+	assert.ErrorIs(t, err, ErrLimitReached)
+
+	// Verify count
+	count, err := store2.CountByUser(ctx, "user_github_123")
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	// Release one, then reserve again — should work
+	err = store2.Release(ctx, "second", "user_github_123")
+	require.NoError(t, err)
+
+	err = store2.Reserve(ctx, "replacement", "user_github_123")
+	assert.NoError(t, err, "should succeed after releasing a slot")
+
+	// Another user is unaffected by first user's limit
+	err = store2.Reserve(ctx, "other1", "user_github_456")
+	assert.NoError(t, err)
 }

--- a/internal/server/subdomain_test.go
+++ b/internal/server/subdomain_test.go
@@ -229,6 +229,71 @@ func TestSystemReserved(t *testing.T) {
 	assert.False(t, store.IsSystemReserved("myapp"))
 }
 
+func TestCountByUser(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	count, err := store.CountByUser(ctx, "user1")
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+
+	require.NoError(t, store.Reserve(ctx, "app1", "user1"))
+	require.NoError(t, store.Reserve(ctx, "app2", "user1"))
+
+	count, err = store.CountByUser(ctx, "user1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Other user's subdomains don't count
+	require.NoError(t, store.Reserve(ctx, "other", "user2"))
+	count, err = store.CountByUser(ctx, "user1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestReserve_LimitReached(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Reserve max allowed
+	require.NoError(t, store.Reserve(ctx, "app1", "user1"))
+	require.NoError(t, store.Reserve(ctx, "app2", "user1"))
+	require.NoError(t, store.Reserve(ctx, "app3", "user1"))
+
+	// 4th should fail
+	err := store.Reserve(ctx, "app4", "user1")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrLimitReached)
+
+	// Re-reserving existing one should still work (no-op)
+	err = store.Reserve(ctx, "app1", "user1")
+	assert.NoError(t, err)
+
+	// Different user can still reserve
+	err = store.Reserve(ctx, "app4", "user2")
+	assert.NoError(t, err)
+}
+
+func TestReserve_LimitAfterRelease(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.Reserve(ctx, "app1", "user1"))
+	require.NoError(t, store.Reserve(ctx, "app2", "user1"))
+	require.NoError(t, store.Reserve(ctx, "app3", "user1"))
+
+	// At limit — release one
+	require.NoError(t, store.Release(ctx, "app2", "user1"))
+
+	// Now can reserve a new one
+	err := store.Reserve(ctx, "app4", "user1")
+	assert.NoError(t, err)
+
+	// But not another
+	err = store.Reserve(ctx, "app5", "user1")
+	assert.ErrorIs(t, err, ErrLimitReached)
+}
+
 func TestValidateSubdomain(t *testing.T) {
 	tests := []struct {
 		subdomain string


### PR DESCRIPTION
## Summary
- Custom subdomains are now **auto-reserved** for the authenticated user on first use (both CF edge and SQLite self-hosted)
- Each user is limited to **3 custom subdomains** max — enforced in both D1 and SQLite
- Added `CountByUser()` method to `SubdomainStore` interface
- Added `ErrLimitReached` error sentinel + `MaxSubdomainsPerUser` constant

## Test plan
- [x] 25 Go unit tests pass (3 new: CountByUser, LimitReached, LimitAfterRelease)
- [x] Integration test updated with Scenario 7 (rate limit + release + re-reserve)
- [x] Full `go test ./...` passes
- [x] Edge tunnel.ts type-checks (pre-existing test type issue unrelated)