### PR TITLE
Update roadmap to reflect 12-phase dual-track plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,13 +242,20 @@ go test ./... -cover
 
 ## Roadmap
 
-- [x] **Phase 1** — Core tunnel (`wormhole http 3000` -> public URL)
-- [x] **Phase 2** — HTTPS, custom subdomains, GitHub OAuth
-- [x] **Phase 3** — Traffic inspector, replay, HAR export
-- [ ] **Phase 4** — API keys, rate limiting
-- [ ] **Phase 5** — Self-hosted relay + TCP tunnels
-- [ ] **Phase 6** — P2P mode (direct connections, no relay)
-- [ ] **Phase 7** — Polish (CI/CD, Homebrew, docs)
+Wormhole is built on a **dual-track architecture**: Cloudflare Workers (free, no setup) + self-hosted Go relay (full control, unlimited scale).
+
+- [x] **Phase 1** — Core tunnel (`wormhole http 3000` → public URL, WebSocket passthrough)
+- [x] **Phase 2** — HTTPS, custom subdomains (auto-reserve, 3/user limit), GitHub OAuth
+- [x] **Phase 3** — Traffic inspector, request replay, HAR export, curl generation
+- [ ] **Phase 4** — Self-hosted Go relay (`wormhole server`, QUIC transport, SQLite persistence)
+- [ ] **Phase 5** — Auth & multi-user (API keys, team tokens, CF + self-hosted middleware)
+- [ ] **Phase 6** — Stream multiplexing (virtual streams over single WebSocket, backpressure)
+- [ ] **Phase 7** — Plugin system (request/response pipeline, custom auth, transforms)
+- [ ] **Phase 8** — Observability (Prometheus metrics, structured logs, health endpoints)
+- [ ] **Phase 9** — Protocol evolution (version negotiation, TLS pinning, binary framing)
+- [ ] **Phase 10** — Enterprise hardening (connection limits, mTLS, audit logs, RBAC)
+- [ ] **Phase 11** — P2P mode (`wormhole share`, WebRTC direct connections, no relay)
+- [ ] **Phase 12** — Polish & ship (homepage, docs site, video demos, package registries)
 
 ## Author
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1053,31 +1053,51 @@
             <ul class="roadmap">
                 <li>
                     <span class="roadmap-check done">&#10003;</span>
-                    <div><strong>Phase 1</strong> &mdash; Core tunnel (<code>wormhole http 3000</code> &#8594; public URL)</div>
+                    <div><strong>Phase 1</strong> &mdash; Core tunnel (<code>wormhole http 3000</code> &#8594; public URL, WebSocket passthrough)</div>
                 </li>
                 <li>
                     <span class="roadmap-check done">&#10003;</span>
-                    <div><strong>Phase 2</strong> &mdash; HTTPS, custom subdomains, GitHub OAuth</div>
+                    <div><strong>Phase 2</strong> &mdash; HTTPS, custom subdomains (auto-reserve, 3/user limit), GitHub OAuth</div>
                 </li>
                 <li>
                     <span class="roadmap-check done">&#10003;</span>
-                    <div><strong>Phase 3</strong> &mdash; Traffic inspector, replay, HAR export</div>
+                    <div><strong>Phase 3</strong> &mdash; Traffic inspector, request replay, HAR export, curl generation</div>
                 </li>
                 <li>
                     <span class="roadmap-check pending">&nbsp;</span>
-                    <div><strong>Phase 4</strong> &mdash; API keys, rate limiting</div>
+                    <div><strong>Phase 4</strong> &mdash; Self-hosted Go relay (<code>wormhole server</code>, QUIC transport, SQLite persistence)</div>
                 </li>
                 <li>
                     <span class="roadmap-check pending">&nbsp;</span>
-                    <div><strong>Phase 5</strong> &mdash; Self-hosted relay + TCP tunnels</div>
+                    <div><strong>Phase 5</strong> &mdash; Auth &amp; multi-user (API keys, team tokens, CF + self-hosted middleware)</div>
                 </li>
                 <li>
                     <span class="roadmap-check pending">&nbsp;</span>
-                    <div><strong>Phase 6</strong> &mdash; P2P mode (direct connections, no relay)</div>
+                    <div><strong>Phase 6</strong> &mdash; Stream multiplexing (virtual streams over single WebSocket, backpressure)</div>
                 </li>
                 <li>
                     <span class="roadmap-check pending">&nbsp;</span>
-                    <div><strong>Phase 7</strong> &mdash; Polish (CI/CD, Homebrew, docs)</div>
+                    <div><strong>Phase 7</strong> &mdash; Plugin system (request/response pipeline, custom auth, transforms)</div>
+                </li>
+                <li>
+                    <span class="roadmap-check pending">&nbsp;</span>
+                    <div><strong>Phase 8</strong> &mdash; Observability (Prometheus metrics, structured logs, health endpoints)</div>
+                </li>
+                <li>
+                    <span class="roadmap-check pending">&nbsp;</span>
+                    <div><strong>Phase 9</strong> &mdash; Protocol evolution (version negotiation, TLS pinning, binary framing)</div>
+                </li>
+                <li>
+                    <span class="roadmap-check pending">&nbsp;</span>
+                    <div><strong>Phase 10</strong> &mdash; Enterprise hardening (connection limits, mTLS, audit logs, RBAC)</div>
+                </li>
+                <li>
+                    <span class="roadmap-check pending">&nbsp;</span>
+                    <div><strong>Phase 11</strong> &mdash; P2P mode (<code>wormhole share</code>, WebRTC direct connections, no relay)</div>
+                </li>
+                <li>
+                    <span class="roadmap-check pending">&nbsp;</span>
+                    <div><strong>Phase 12</strong> &mdash; Polish &amp; ship (homepage, docs site, video demos, package registries)</div>
                 </li>
             </ul>
         </section>


### PR DESCRIPTION
## Summary
- Updated README.md roadmap with all 12 phases and accurate descriptions
- Updated docs/index.html (GitHub Pages) roadmap to match
- Phases 1-3 marked done, phases 4-12 marked pending
- Added dual-track note (Cloudflare Workers + self-hosted Go relay)

## What changed per phase
- Phase 4: API keys → Self-hosted Go relay (wormhole server, QUIC, SQLite)
- Phase 5: Self-hosted relay → Auth & multi-user (API keys, team tokens)
- Phase 6: P2P mode → Stream multiplexing (virtual streams, backpressure)
- Phase 7: Polish → Plugin system (request/response pipeline)
- Phases 8-12: Added (Observability, Protocol evolution, Enterprise hardening, P2P mode, Polish & ship)